### PR TITLE
Set FFI_TRAMPOLINE_WHOLE_DYLIB on aarch64-apple-darwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -198,6 +198,13 @@ if test "x$libffi_cv_as_ptrauth" = xyes; then
 	      [Define if your compiler supports pointer authentication.])
 fi
 
+# Set additional defines for Apple Silicon.
+case "$target" in
+    aarch64-apple-darwin* | arm64-apple-darwin*)
+	AC_DEFINE([FFI_TRAMPOLINE_WHOLE_DYLIB], 1, [Creating a separate libffi-trampolines.dylib and remapping the entire dylib])
+	;;
+esac
+
 # On PaX enable kernels that have MPROTECT enable we can't use PROT_EXEC.
 AC_ARG_ENABLE(pax_emutramp,
   [  --enable-pax_emutramp       enable pax emulated trampolines, for we can't use PROT_EXEC],

--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -357,6 +357,11 @@ ffi_prep_closure_loc (ffi_closure*,
 		      void *user_data,
 		      void*codeloc);
 
+#if defined(__x86_64__) || defined(__arm64__)
+FFI_API ffi_closure *
+ffi_find_closure_for_code(void *code);
+#endif
+
 #ifdef __sgi
 # pragma pack 8
 #endif

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -647,12 +647,13 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
 		state.ngrn = N_X_ARG_REG;
 		/* Note that the default abi extends each argument
 		   to a full 64-bit slot, while the iOS abi allocates
-		   only enough space. */
+		   only enough space, except for variadic arguments. */
 #ifdef __APPLE__
-		memcpy(d, a, s);
-#else
-		*(ffi_arg *)d = ext;
+		if (!state.allocating_variadic)
+		  memcpy(d, a, s);
+		else
 #endif
+		  *(ffi_arg *)d = ext;
 	      }
 	  }
 	  break;

--- a/src/aarch64/internal.h
+++ b/src/aarch64/internal.h
@@ -65,3 +65,24 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #define N_X_ARG_REG		8
 #define N_V_ARG_REG		8
 #define CALL_CONTEXT_SIZE	(N_V_ARG_REG * 16 + N_X_ARG_REG * 8)
+
+/* Helpers for writing assembly compatible with arm ptr auth */
+#ifdef LIBFFI_ASM
+
+#ifdef HAVE_PTRAUTH
+#define SIGN_LR pacibsp
+#define SIGN_LR_WITH_REG(x) pacib lr, x
+#define AUTH_LR_AND_RET retab
+#define AUTH_LR_WITH_REG(x) autib lr, x
+#define BRANCH_AND_LINK_TO_REG blraaz
+#define BRANCH_TO_REG braaz
+#else
+#define SIGN_LR
+#define SIGN_LR_WITH_REG(x)
+#define AUTH_LR_AND_RET ret
+#define AUTH_LR_WITH_REG(x)
+#define BRANCH_AND_LINK_TO_REG blr
+#define BRANCH_TO_REG br
+#endif
+
+#endif

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -58,14 +58,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #define PTR_SIZE	8
 #endif
 
-#if FFI_EXEC_TRAMPOLINE_TABLE && defined(__MACH__) && defined(HAVE_PTRAUTH)
-# define BR(r)  braaz r
-# define BLR(r) blraaz r
-#else
-# define BR(r)  br r
-# define BLR(r) blr r
-#endif
-
 	.text
 	.align 4
 
@@ -86,9 +78,14 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 	cfi_startproc
 CNAME(ffi_call_SYSV):
+	/* Sign the lr with x1 since that is where it will be stored */
+	SIGN_LR_WITH_REG(x1)
+
 	/* Use a stack frame allocated by our caller.  */
-	cfi_def_cfa(x1, 32);
+	cfi_def_cfa(x1, 40);
 	stp	x29, x30, [x1]
+	mov	x9, sp
+	str	x9, [x1, #32]
 	mov	x29, x1
 	mov	sp, x0
 	cfi_def_cfa_register(x29)
@@ -119,13 +116,15 @@ CNAME(ffi_call_SYSV):
 	/* Deallocate the context, leaving the stacked arguments.  */
 	add	sp, sp, #CALL_CONTEXT_SIZE
 
-	BLR(x9)				/* call fn */
+	BRANCH_AND_LINK_TO_REG     x9			/* call fn */
 
 	ldp	x3, x4, [x29, #16]	/* reload rvalue and flags */
 
 	/* Partially deconstruct the stack frame.  */
-	mov     sp, x29
+	ldr	x9, [x29, #32]
+	mov	sp, x9
 	cfi_def_cfa_register (sp)
+	mov	x2, x29			/* Preserve for auth */
 	ldp     x29, x30, [x29]
 
 	/* Save the return value as directed.  */
@@ -139,70 +138,75 @@ CNAME(ffi_call_SYSV):
 	   and therefore we want to extend to 64 bits; these types
 	   have two consecutive entries allocated for them.  */
 	.align	4
-0:	ret				/* VOID */
+0:	b 99f				/* VOID */
 	nop
 1:	str	x0, [x3]		/* INT64 */
-	ret
+	b 99f
 2:	stp	x0, x1, [x3]		/* INT128 */
-	ret
+	b 99f
 3:	brk	#1000			/* UNUSED */
-	ret
+	b 99f
 4:	brk	#1000			/* UNUSED */
-	ret
+	b 99f
 5:	brk	#1000			/* UNUSED */
-	ret
+	b 99f
 6:	brk	#1000			/* UNUSED */
-	ret
+	b 99f
 7:	brk	#1000			/* UNUSED */
-	ret
+	b 99f
 8:	st4	{ v0.s, v1.s, v2.s, v3.s }[0], [x3]	/* S4 */
-	ret
+	b 99f
 9:	st3	{ v0.s, v1.s, v2.s }[0], [x3]	/* S3 */
-	ret
+	b 99f
 10:	stp	s0, s1, [x3]		/* S2 */
-	ret
+	b 99f
 11:	str	s0, [x3]		/* S1 */
-	ret
+	b 99f
 12:	st4	{ v0.d, v1.d, v2.d, v3.d }[0], [x3]	/* D4 */
-	ret
+	b 99f
 13:	st3	{ v0.d, v1.d, v2.d }[0], [x3]	/* D3 */
-	ret
+	b 99f
 14:	stp	d0, d1, [x3]		/* D2 */
-	ret
+	b 99f
 15:	str	d0, [x3]		/* D1 */
-	ret
+	b 99f
 16:	str	q3, [x3, #48]		/* Q4 */
 	nop
 17:	str	q2, [x3, #32]		/* Q3 */
 	nop
 18:	stp	q0, q1, [x3]		/* Q2 */
-	ret
+	b 99f
 19:	str	q0, [x3]		/* Q1 */
-	ret
+	b 99f
 20:	uxtb	w0, w0			/* UINT8 */
 	str	x0, [x3]
-21:	ret				/* reserved */
+21:	b 99f				/* reserved */
 	nop
 22:	uxth	w0, w0			/* UINT16 */
 	str	x0, [x3]
-23:	ret				/* reserved */
+23:	b 99f				/* reserved */
 	nop
 24:	mov	w0, w0			/* UINT32 */
 	str	x0, [x3]
-25:	ret				/* reserved */
+25:	b 99f				/* reserved */
 	nop
 26:	sxtb	x0, w0			/* SINT8 */
 	str	x0, [x3]
-27:	ret				/* reserved */
+27:	b 99f				/* reserved */
 	nop
 28:	sxth	x0, w0			/* SINT16 */
 	str	x0, [x3]
-29:	ret				/* reserved */
+29:	b 99f				/* reserved */
 	nop
 30:	sxtw	x0, w0			/* SINT32 */
 	str	x0, [x3]
-31:	ret				/* reserved */
+31:	b 99f				/* reserved */
 	nop
+
+	/* Return now that result has been populated. */
+99:
+	AUTH_LR_WITH_REG(x2)
+	ret
 
 	cfi_endproc
 
@@ -212,6 +216,8 @@ CNAME(ffi_call_SYSV):
 	.type	CNAME(ffi_call_SYSV), #function
 	.size CNAME(ffi_call_SYSV), .-CNAME(ffi_call_SYSV)
 #endif
+
+#if FFI_CLOSURES
 
 /* ffi_closure_SYSV
 
@@ -232,6 +238,7 @@ CNAME(ffi_call_SYSV):
 	.align 4
 CNAME(ffi_closure_SYSV_V):
 	cfi_startproc
+	SIGN_LR
 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
 	cfi_rel_offset (x29, 0)
@@ -255,6 +262,7 @@ CNAME(ffi_closure_SYSV_V):
 	.align	4
 	cfi_startproc
 CNAME(ffi_closure_SYSV):
+	SIGN_LR
 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
 	cfi_rel_offset (x29, 0)
@@ -271,7 +279,9 @@ CNAME(ffi_closure_SYSV):
 	/* Load ffi_closure_inner arguments.  */
 	ldp	PTR_REG(0), PTR_REG(1), [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET]	/* load cif, fn */
 	ldr	PTR_REG(2), [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET+PTR_SIZE*2]	/* load user_data */
+#ifdef FFI_GO_CLOSURES
 .Ldo_closure:
+#endif
 	add	x3, sp, #16				/* load context */
 	add	x4, sp, #ffi_closure_SYSV_FS		/* load stack */
 	add	x5, sp, #16+CALL_CONTEXT_SIZE		/* load rvalue */
@@ -279,9 +289,6 @@ CNAME(ffi_closure_SYSV):
 	bl      CNAME(ffi_closure_SYSV_inner)
 
 	/* Load the return value as directed.  */
-#if FFI_EXEC_TRAMPOLINE_TABLE && defined(__MACH__) && defined(HAVE_PTRAUTH)
-	autiza	x1
-#endif
 	adr	x1, 0f
 	and	w0, w0, #AARCH64_RET_MASK
 	add	x1, x1, x0, lsl #3
@@ -357,7 +364,7 @@ CNAME(ffi_closure_SYSV):
 	cfi_adjust_cfa_offset (-ffi_closure_SYSV_FS)
 	cfi_restore (x29)
 	cfi_restore (x30)
-	ret
+	AUTH_LR_AND_RET
 	cfi_endproc
 
 	.globl	CNAME(ffi_closure_SYSV)
@@ -376,7 +383,7 @@ CNAME(ffi_closure_trampoline_table_page):
     .rept PAGE_MAX_SIZE / FFI_TRAMPOLINE_SIZE
     adr x16, -PAGE_MAX_SIZE
     ldp x17, x16, [x16]
-    BR(x16)
+    br x16
 	nop		/* each entry in the trampoline config page is 2*sizeof(void*) so the trampoline itself cannot be smaller than 16 bytes */
     .endr
 
@@ -443,6 +450,7 @@ CNAME(ffi_go_closure_SYSV):
 	.size	CNAME(ffi_go_closure_SYSV), . - CNAME(ffi_go_closure_SYSV)
 #endif
 #endif /* FFI_GO_CLOSURES */
+#endif /* FFI_CLOSURES */
 #endif /* __arm64__ */
 
 #if defined __ELF__ && defined __linux__

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -82,7 +82,15 @@ CNAME(ffi_call_SYSV):
 	SIGN_LR_WITH_REG(x1)
 
 	/* Use a stack frame allocated by our caller.  */
+#ifdef HAVE_PTRAUTH && defined(__APPLE__)
+	/* darwin's libunwind assumes that the cfa is the sp and that's the data
+	 * used to sign the lr.  In order to allow unwinding through this
+	 * function it is necessary to point the cfa at the signing register.
+	 */
+	cfi_def_cfa(x1, 0);
+#else
 	cfi_def_cfa(x1, 40);
+#endif
 	stp	x29, x30, [x1]
 	mov	x9, sp
 	str	x9, [x1, #32]

--- a/src/aarch64/trampoline.S
+++ b/src/aarch64/trampoline.S
@@ -1,0 +1,44 @@
+#ifdef __arm64__
+
+#define LIBFFI_ASM
+#include <fficonfig.h>
+#include <ffi.h>
+#include <ffi_cfi.h>
+#include "internal.h"
+
+#ifdef FFI_EXEC_TRAMPOLINE_TABLE
+
+#ifdef __MACH__
+#include <mach/machine/vm_param.h>
+#endif
+
+#ifdef HAVE_MACHINE_ASM_H
+# include <machine/asm.h>
+#else
+# ifdef __USER_LABEL_PREFIX__
+#  define CONCAT1(a, b) CONCAT2(a, b)
+#  define CONCAT2(a, b) a ## b
+#  define CNAME(x) CONCAT1 (__USER_LABEL_PREFIX__, x)
+# else
+#  define CNAME(x) x
+# endif
+#endif
+
+.set page_max_size, PAGE_MAX_SIZE
+.align PAGE_MAX_SHIFT
+.text
+.globl CNAME(ffi_closure_trampoline_table_page)
+CNAME(ffi_closure_trampoline_table_page):
+    .rept PAGE_MAX_SIZE / FFI_TRAMPOLINE_SIZE
+#ifdef FFI_TRAMPOLINE_WHOLE_DYLIB
+    adr x16, -(2 * PAGE_MAX_SIZE)
+#else
+    adr x16, -PAGE_MAX_SIZE
+#endif
+    ldp x17, x16, [x16]
+    BRANCH_TO_REG x16
+	nop		/* each entry in the trampoline config page is 2*sizeof(void*) so the trampoline itself cannot be smaller that 16 bytes */
+    .endr
+
+#endif /* FFI_EXEC_TRAMPOLINE_TABLE */
+#endif /* __arm64 */

--- a/src/arm/ffi.c
+++ b/src/arm/ffi.c
@@ -426,12 +426,14 @@ ffi_call (ffi_cif *cif, void (*fn) (void), void *rvalue, void **avalue)
   ffi_call_int (cif, fn, rvalue, avalue, NULL);
 }
 
+#ifdef FFI_GO_CLOSURES
 void
 ffi_call_go (ffi_cif *cif, void (*fn) (void), void *rvalue,
 	     void **avalue, void *closure)
 {
   ffi_call_int (cif, fn, rvalue, avalue, closure);
 }
+#endif
 
 static void *
 ffi_prep_incoming_args_SYSV (ffi_cif *cif, void *rvalue,
@@ -569,8 +571,11 @@ ffi_closure_inner_VFP (ffi_cif *cif,
 
 void ffi_closure_SYSV (void) FFI_HIDDEN;
 void ffi_closure_VFP (void) FFI_HIDDEN;
+
+#ifdef FFI_GO_CLOSURES
 void ffi_go_closure_SYSV (void) FFI_HIDDEN;
 void ffi_go_closure_VFP (void) FFI_HIDDEN;
+#endif
 
 /* the cif must already be prep'ed */
 
@@ -637,6 +642,7 @@ ffi_prep_closure_loc (ffi_closure * closure,
   return FFI_OK;
 }
 
+#ifdef FFI_GO_CLOSURES
 ffi_status
 ffi_prep_go_closure (ffi_go_closure *closure, ffi_cif *cif,
 		     void (*fun) (ffi_cif *, void *, void **, void *))
@@ -658,6 +664,7 @@ ffi_prep_go_closure (ffi_go_closure *closure, ffi_cif *cif,
 
   return FFI_OK;
 }
+#endif
 
 /* Below are routines for VFP hard-float support. */
 

--- a/src/arm/ffi.c
+++ b/src/arm/ffi.c
@@ -536,6 +536,8 @@ ffi_prep_incoming_args_VFP (ffi_cif *cif, void *rvalue, char *stack,
   return rvalue;
 }
 
+#if FFI_CLOSURES
+
 struct closure_frame
 {
   char vfp_space[8*8] __attribute__((aligned(8)));
@@ -665,6 +667,8 @@ ffi_prep_go_closure (ffi_go_closure *closure, ffi_cif *cif,
   return FFI_OK;
 }
 #endif
+
+#endif /* FFI_CLOSURES */
 
 /* Below are routines for VFP hard-float support. */
 

--- a/src/arm/sysv.S
+++ b/src/arm/sysv.S
@@ -208,6 +208,7 @@ E(ARM_TYPE_STRUCT)
 	UNWIND(.fnend)
 ARM_FUNC_END(ffi_call_SYSV)
 
+#if FFI_CLOSURES
 
 /*
 	int ffi_closure_inner_* (cif, fun, user_data, frame)
@@ -353,6 +354,8 @@ E(ARM_TYPE_STRUCT)
 	ldm	sp, {sp,pc}
 	cfi_endproc
 ARM_FUNC_END(ffi_closure_ret)
+
+#endif /* FFI_CLOSURES */
 
 #if FFI_EXEC_TRAMPOLINE_TABLE
 

--- a/src/prep_cif.c
+++ b/src/prep_cif.c
@@ -234,7 +234,7 @@ ffi_status ffi_prep_cif_var(ffi_cif *cif,
   return ffi_prep_cif_core(cif, abi, 1, nfixedargs, ntotalargs, rtype, atypes);
 }
 
-#if FFI_CLOSURES
+#if FFI_CLOSURES && FFI_LEGACY_CLOSURE_API
 
 ffi_status
 ffi_prep_closure (ffi_closure* closure,

--- a/src/x86/ffi.c
+++ b/src/x86/ffi.c
@@ -397,12 +397,14 @@ ffi_call (ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)
   ffi_call_int (cif, fn, rvalue, avalue, NULL);
 }
 
+#ifdef FFI_GO_CLOSURES
 void
 ffi_call_go (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	     void **avalue, void *closure)
 {
   ffi_call_int (cif, fn, rvalue, avalue, closure);
 }
+#endif
 
 /** private members **/
 
@@ -575,6 +577,8 @@ ffi_prep_closure_loc (ffi_closure* closure,
   return FFI_OK;
 }
 
+#ifdef FFI_GO_CLOSURES
+
 void FFI_HIDDEN ffi_go_closure_EAX(void);
 void FFI_HIDDEN ffi_go_closure_ECX(void);
 void FFI_HIDDEN ffi_go_closure_STDCALL(void);
@@ -610,6 +614,8 @@ ffi_prep_go_closure (ffi_go_closure* closure, ffi_cif* cif,
 
   return FFI_OK;
 }
+
+#endif /* FFI_GO_CLOSURES */
 
 /* ------- Native raw API support -------------------------------- */
 

--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -688,6 +688,8 @@ ffi_call (ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)
   ffi_call_int (cif, fn, rvalue, avalue, NULL);
 }
 
+#ifdef FFI_GO_CLOSURES
+
 #ifndef __ILP32__
 extern void
 ffi_call_go_efi64(ffi_cif *cif, void (*fn)(void), void *rvalue,
@@ -708,6 +710,7 @@ ffi_call_go (ffi_cif *cif, void (*fn)(void), void *rvalue,
   ffi_call_int (cif, fn, rvalue, avalue, closure);
 }
 
+#endif /* FFI_GO_CLOSURES */
 
 extern void ffi_closure_unix64(void) FFI_HIDDEN;
 extern void ffi_closure_unix64_sse(void) FFI_HIDDEN;
@@ -856,6 +859,8 @@ ffi_closure_unix64_inner(ffi_cif *cif,
   return flags;
 }
 
+#ifdef FFI_GO_CLOSURES
+
 extern void ffi_go_closure_unix64(void) FFI_HIDDEN;
 extern void ffi_go_closure_unix64_sse(void) FFI_HIDDEN;
 
@@ -884,5 +889,7 @@ ffi_prep_go_closure (ffi_go_closure* closure, ffi_cif* cif,
 
   return FFI_OK;
 }
+
+#endif /* FFI_GO_CLOSURES */
 
 #endif /* __x86_64__ */

--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -766,6 +766,12 @@ ffi_prep_closure_loc (ffi_closure* closure,
   return FFI_OK;
 }
 
+ffi_closure *
+ffi_find_closure_for_code(void *code)
+{
+    return (ffi_closure *) code;
+}
+
 int FFI_HIDDEN
 ffi_closure_unix64_inner(ffi_cif *cif,
 			 void (*fun)(ffi_cif*, void*, void**, void*),

--- a/src/x86/ffiw64.c
+++ b/src/x86/ffiw64.c
@@ -187,7 +187,10 @@ EFI64(ffi_call_go)(ffi_cif *cif, void (*fn)(void), void *rvalue,
 
 
 extern void ffi_closure_win64(void) FFI_HIDDEN;
+
+#ifdef FFI_GO_CLOSURES
 extern void ffi_go_closure_win64(void) FFI_HIDDEN;
+#endif
 
 ffi_status
 EFI64(ffi_prep_closure_loc)(ffi_closure* closure,
@@ -227,6 +230,7 @@ EFI64(ffi_prep_closure_loc)(ffi_closure* closure,
   return FFI_OK;
 }
 
+#ifdef FFI_GO_CLOSURES
 ffi_status
 EFI64(ffi_prep_go_closure)(ffi_go_closure* closure, ffi_cif* cif,
 		     void (*fun)(ffi_cif*, void*, void**, void*))
@@ -246,6 +250,7 @@ EFI64(ffi_prep_go_closure)(ffi_go_closure* closure, ffi_cif* cif,
 
   return FFI_OK;
 }
+#endif
 
 struct win64_closure_frame
 {

--- a/testsuite/libffi.closures/huge_struct.c
+++ b/testsuite/libffi.closures/huge_struct.c
@@ -9,6 +9,8 @@
 /* { dg-options -mlong-double-128 { target powerpc64*-*-linux* } } */
 /* { dg-options -Wformat=0 { target moxie*-*-elf or1k-*-* } } */
 
+#include <inttypes.h>
+
 #include "ffitest.h"
 
 typedef	struct BigStruct{


### PR DESCRIPTION
The Apple libffi fork uses a hard-coded config header that defines this
preprocessor symbol. This PR adds the symbol to configure so that is
works with the autotools build system.

Signed-off-by: Nathan Hjelm <hjelmn@cs.unm.edu>